### PR TITLE
fix: list both application and management users

### DIFF
--- a/controllers/users.js
+++ b/controllers/users.js
@@ -39,9 +39,9 @@ exports.getUsers = async () => {
             timeout: 0
         })
             .then((res) => {
-                res.sort((a, b) => a.created_at.localeCompare(b.created_at));
+                users = [...res.application_users, ...res.management_users].sort((a, b) => a.created_at.localeCompare(b.created_at));
                 console.table(
-                    res.map((user) => {
+                    users.map((user) => {
                         return {
                             user_name: user.username,
                             created_at: user.created_at,


### PR DESCRIPTION
Listing the users did not work since it used to treat the result as a single array, but it contains both application users and management users.
This commit merges both arrays into a single one that is still sorted by creation date.